### PR TITLE
chore: bump pinned tool versions (2026-07-06)

### DIFF
--- a/root/private_dot_config/mise/config.toml.tmpl
+++ b/root/private_dot_config/mise/config.toml.tmpl
@@ -1,5 +1,5 @@
 [tools]
-starship = "1.25.1"
+starship = "1.26.0"
 lazygit = "0.62.2"
 lazydocker = "0.25.2"
 ast-grep = "0.44.0"
@@ -12,15 +12,15 @@ ripgrep = "15.1.0"
 lsd = "1.2.0"
 gh = "2.95.0"
 zoxide = "0.9.9"
-worktrunk = "0.61.0"
+worktrunk = "0.63.0"
 cloudflared = "2026.6.1"
-aube = "1.23.0"
-usage = "3.5.0"
+aube = "1.25.1"
+usage = "3.5.3"
 
-"github:Ataraxy-Labs/sem" = "0.13.0"
-"github:backnotprop/plannotator" = "0.21.1"
+"github:Ataraxy-Labs/sem" = "0.14.1"
+"github:backnotprop/plannotator" = "0.21.3"
 {{ if ne .chezmoi.os "windows" -}}
-herdr = "0.7.0"
+herdr = "0.7.1"
 zellij = "0.44.3"
 {{- end }}
 {{ if not .isDc -}}
@@ -28,7 +28,7 @@ go = "1.26.4"
 node = "lts"
 bun = "1.3.14"
 python = "3.14.6"
-pnpm = "11.8.0"
+pnpm = "11.9.0"
 {{- end }}
 
 [settings]


### PR DESCRIPTION
## Version audit — 2026-07-06

Source: `root/private_dot_config/mise/config.toml.tmpl`. Age gate: `minimum_release_age = "7d"` → eligibility cutoff **2026-06-29** (releases published after this date are deferred, not bumped, even if newer). Only exact-pinned tools are considered; `latest`/`lts` entries (node) are untouched.

### Bumped (8)

#### starship
pinned: 1.25.1 → **1.26.0** (2026-06-28)
security: none
features: git status shows `git am` progress; SHA256 support; nix-shell module depth variable; pixi module `PIXI_PROJECT_NAME`; time module timezone (jiff) fixes; gcloud region env var fix; maven/node false-positive detection fixes; statusline null context_window fix
breaking: none

#### worktrunk
pinned: 0.61.0 → **0.63.0** (2026-06-29)
deferred: 0.64.0 released 2026-06-30, eligible 2026-07-07; 0.65.0 released 2026-07-02, eligible 2026-07-09
security: none in 0.62.0/0.63.0. **0.64.0 (deferred) fixes a git-argument-injection issue** (user-controlled refs now fenced behind `--end-of-options`) — worth fast-tracking once eligible on 2026-07-07
features: browse open PRs/MRs in picker w/ live CI status, Windows picker support, `[list] columns` config, performance profiler, `WORKTRUNK_VERBOSE`, deduped git subprocess calls, on-disk PR-comment cache, atomic branch deletion, statusline width fix
breaking: 0.62.0 remaps picker shortcut: remove moved from `Alt-r` to `Alt-x`

#### aube
pinned: 1.23.0 → **1.25.1** (2026-06-26)
deferred: 1.25.2 released 2026-07-01, eligible 2026-07-08
security: 1.24.0 adds a managed hardening-configuration system and enforces trust policy when reusing existing lockfiles; no CVEs
features: `aube install --dry-run`, CycloneDX SBOM dev/peer scoping, shell activation with tool shims (node/npm/pnpm/yarn routed through aube), new `aube node` subcommand, `minimumReleaseAgeExclude` glob/version-union support, npm optional-natives fix
breaking: none (stays in 1.x); note 1.24.0's lockfile trust-policy enforcement could reject previously-accepted untrusted lockfiles

#### usage
pinned: 3.5.0 → **3.5.3** (2026-06-23)
security: none
features: dedupe required-flag validation errors, isolated zsh completion options, variadic args capture unknown flags, restored musl/prebuilt binary publishing, CLI help shows negated `--flag`/`--no-flag` pairs, zsh default-completion fix
breaking: none

#### github:Ataraxy-Labs/sem
pinned: 0.13.0 → **0.14.1** (2026-06-23)
deferred: 0.15.0–0.20.0 released 2026-07-01 through 2026-07-05, eligible 2026-07-08 through 2026-07-12
security: none
features: maintenance only — fixes broken Intel macOS cross-build (openssl-sys) so binaries publish for all platforms again
breaking: none

#### github:backnotprop/plannotator
pinned: 0.21.1 → **0.21.3** (2026-06-28)
deferred: 0.21.4 released 2026-07-01, eligible 2026-07-08; 0.22.0 released 2026-07-05, eligible 2026-07-12
security: none
features: Custom Reviews as Agent Skills, Cursor and OpenCode review engines, fixed deleted-annotation persistence, file-scoped code review comments, VS Code clipboard/keyboard fixes, Codex Ask AI transport improvements
breaking: none

#### herdr
pinned: 0.7.0 → **0.7.1** (2026-06-24)
security: none
features: `[update].version_check`/`manifest_check` config, `HERDR_AGENT` env var for containerized agent detection, `ui.pane_borders`/`ui.pane_gaps` config, user keybindings override defaults, worktree creation checks out existing local branches, improved OMP/OpenCode/Pi/Devin hook integrations, 18 bug fixes (Windows paste/clipboard, CJK branch truncation, Kitty file transfer)
breaking: none

#### pnpm
pinned: 11.8.0 → **11.9.0** (2026-06-23)
deferred: 11.10.0 released 2026-07-04, eligible 2026-07-11
security: none (recent pnpm CVEs were all patched well before 11.8.0)
features: tarball integrity verification for on-demand-registry tarballs, `pnpm sbom --exclude-peers`, fixed nondeterministic peer resolution causing lockfile churn, Windows `dlx` path/lifecycle-script fixes, `pnpm audit` perf fix on cyclic dependency graphs
breaking: none (custom-resolver protocol endpoint relocation only affects self-hosted registries implementing that protocol)

### Current — no eligible update (14)

- lazygit: current. Deferred: 0.63.0 released 2026-07-04, eligible 2026-07-11 (adds direnv support, configurable side panels, background polling, safer worktree create/delete)
- lazydocker: current (0.25.2 is still latest, published 2026-04-19)
- ast-grep: current. Deferred: 0.44.1 released 2026-07-04, eligible 2026-07-11 (maintenance only)
- hyperfine: current
- duf: current
- fd: current
- fzf: current
- jq: current (1.8.2 already carries fixes for the CVEs in its own changelog; nothing newer)
- ripgrep: current (15.1.0 confirmed as the real latest release, published 2025-10-22 — verified directly against upstream after an initial sanity-check flag)
- lsd: current
- gh: current. **Deferred: 2.96.0 released 2026-07-02, eligible 2026-07-09 — fixes a critical `gh codespace jupyter` command-execution vulnerability (GHSA-8cg3-r6g9-fpg2).** Recommend fast-tracking this bump the moment it clears the age gate.
- zoxide: current. Deferred: 0.10.0 released 2026-07-04, eligible 2026-07-11 (atuin-history fetching, DB auto-detect, RISC-V Linux support)
- cloudflared: current (2026.6.1 is still latest, published 2026-06-18)
- zellij: current

### Current — language runtimes, treated conservatively (3)

- go: current (1.26.4 is latest stable; 1.27 exists only as an unreleased RC)
- bun: current
- python: current (3.14.6 is the latest 3.14.x patch; 3.14.7 not yet released; 3.15 still in beta)

### Withheld

None — no eligible target for any tool crosses a major-version boundary.

---
*Digest generated by an automated version-bump audit against each tool's authoritative GitHub Releases (or go.dev/python.org for runtimes), cross-checked via releases.atom feeds against the 2026-06-29 eligibility cutoff (`minimum_release_age = "7d"`, today 2026-07-06).*


---
_Generated by [Claude Code](https://claude.ai/code/session_015nxPDRCE9fhNNDUNHEKm4c)_