### PR TITLE
chore: bump pinned tool versions (2026-07-20)

### DIFF
--- a/root/private_dot_config/mise/config.toml.tmpl
+++ b/root/private_dot_config/mise/config.toml.tmpl
@@ -12,24 +12,24 @@ ripgrep = "15.1.0"
 lsd = "1.2.0"
 gh = "2.96.0"
 zoxide = "0.10.0"
-worktrunk = "0.65.0"
-cloudflared = "2026.6.1"
+worktrunk = "0.67.0"
+cloudflared = "2026.7.1"
 aube = "1.26.0"
 usage = "3.5.4"
 
-"github:Ataraxy-Labs/sem" = "0.20.0"
-"github:backnotprop/plannotator" = "0.22.0"
-"github:modem-dev/hunk" = "0.16.0"
+"github:Ataraxy-Labs/sem" = "0.21.0"
+"github:backnotprop/plannotator" = "0.23.1"
+"github:modem-dev/hunk" = "0.17.0"
 {{ if ne .chezmoi.os "windows" -}}
 herdr = "0.7.1"
 zellij = "0.44.3"
 {{- end }}
 {{ if not .isDc -}}
-go = "1.26.4"
+go = "1.26.5"
 node = "lts"
 bun = "1.3.14"
 python = "3.14.6"
-pnpm = "11.10.0"
+pnpm = "11.13.0"
 {{- end }}
 
 [settings]


### PR DESCRIPTION
## Summary

Automated audit of exact-pinned tools in `root/private_dot_config/mise/config.toml.tmpl` against upstream releases, gated by `minimum_release_age = "7d"` (eligible only if published on or before **2026-07-13**). 7 tools have an eligible, non-withheld bump; the rest are current or have updates still inside the age gate.

## Bumped in this PR

| Tool | Pinned | Target | Released |
|---|---|---|---|
| `go` | 1.26.4 | **1.26.5** | 2026-07-07 |
| `pnpm` | 11.10.0 | **11.13.0** | 2026-07-13 |
| `worktrunk` | 0.65.0 | **0.67.0** | 2026-07-10 |
| `cloudflared` | 2026.6.1 | **2026.7.1** | 2026-07-09 |
| `github:Ataraxy-Labs/sem` | 0.20.0 | **0.21.0** | 2026-07-10 |
| `github:backnotprop/plannotator` | 0.22.0 | **0.23.1** | 2026-07-12 |
| `github:modem-dev/hunk` | 0.16.0 | **0.17.0** | 2026-07-07 |

### go: 1.26.4 → 1.26.5
- **Security fixes:**
  - `crypto/tls`: Encrypted Client Hello could leak PSK identities during the handshake, letting a passive observer de-anonymize the server hostname even with ECH in use (CVE-2026-42505).
  - `os`: `os.Root` on Unix could follow a symlink outside the root when the final path component was a symlink and the path ended in `/`, e.g. `root.Open("symlink/")` (CVE-2026-39822).
- Also routine compiler/runtime/`go`-command/`net`/`os`/`syscall` bug fixes.
- Patch-level only (stays within 1.26.x), no breaking changes.

### pnpm: 11.10.0 → 11.13.0 (spans 11.11.0, 11.12.0, 11.13.0)
- **Security hardening (11.11.0):** rejects crafted `pnpm-lock.yaml` entries that path-traverse out of the virtual store/`node_modules` (isolated linker, PnP resolver map, global-virtual-store path formatting, and scoped-package-name handling all now validate names/paths). No specific CVE ID found for this fix; it's distinct from the already-older CVE-2026-59195/59196 path-traversal fixes from 11.7.0/11.8.0.
- New features: `pnpm access` (11.11.0); custom fetcher delegation envelope (11.12.0); workspace release management (`pnpm change`, `pnpm version -r`, `pnpm lane`), "Epic Versioning", and a `team` command (11.13.0).
- Fixes: peer-dependency resolution deadlock, `self-update`, `outdated` skipping local deps, `ERR_PNPM_MISSING_TIME` with `trustPolicy: no-downgrade`, `list` crash from too many open files, orphaned Windows child processes, and others.
- No breaking changes documented. 11.13.0 was published 2026-07-13 — exactly at the 7-day boundary; treated as eligible under the digest's date-level gate definition.

### worktrunk: 0.65.0 → 0.67.0 (spans 0.66.0, 0.67.0)
- No CVEs/security fixes. Still pre-1.0, no major-version boundary.
- Features: opt-in JSON schema v2 for `wt list`; `wt config approvals list`/`clear --stale`; Codex activity markers; experimental `--reap` flag for `wt remove` (Unix-only, kills lingering processes holding the worktree); `wt switch -x` now opens an interactive picker with no branch given; subprocess-timing diagnostics.
- Fixes: user hooks no longer leak `wt`'s `GIT_*` env vars into child processes; SCP-style SSH remote URLs with custom usernames now parse; panic fixed on malformed PR markdown tables; `wt step for-each` no longer inherits `GIT_DIR`/`GIT_WORK_TREE`.

### cloudflared: 2026.6.1 → 2026.7.1 (spans 2026.7.0, 2026.7.1)
- Maintenance only — no CVEs, no breaking changes. Added OpenRC init-system support, fixed broken installed-service detection in `systemd uninstall`, consolidated init-system detection, added a Semgrep OSS security-scanning CI workflow (tooling, not a runtime fix).

### sem: 0.20.0 → 0.21.0
- No CVEs, no breaking changes. New cloud-enabled `sem diff` with hosted review URLs; large performance wins (`sem context` ~15s→0.44s, `sem impact` ~3.5s→0.04s, resident MCP server idle memory ~671MB→10MB); fixes for hosted-review upload failures and stale cloud-repo cache state.

### plannotator: 0.22.0 → 0.23.1 (spans 0.23.0, 0.23.1)
- No CVEs. Restores plan-approval compatibility with Claude Code ≥2.1.199; fixes a startup hang on large/slow directory trees (bounded, async file discovery); new `--minimal` install flag; annotate-mode version-diff history; Ask-AI chat input no longer pushed off-screen on long responses.

### hunk: 0.16.0 → 0.17.0
- No CVEs, no breaking changes. Adds an agent-skill menu dialog, menu-bar visibility toggle, `.mts`/`.cts` syntax highlighting, Nix home-manager support, Jujutsu integration; fixes mixed-theme preview rendering, draft-notes key ownership, and Windows path detection.

## Current — no eligible update
`starship` 1.26.0, `lazydocker` 0.25.2, `ast-grep` 0.44.1, `hyperfine` 1.20.0, `duf` 0.9.1, `fd` 10.4.2, `jq` 1.8.2, `lsd` 1.2.0, `gh` 2.96.0, `zoxide` 0.10.0, `zellij` 0.44.3, `bun` 1.3.14, `python` 3.14.6

## Deferred by age gate (not proposed this cycle)
- `lazygit` 0.63.0 → 0.63.1 released 2026-07-15, eligible ~2026-07-22 (regression/stability patch, maintenance only)
- `ripgrep` 15.1.0 → 15.2.0 released 2026-07-15, eligible ~2026-07-22 (gitignore-matching fixes, perf improvements, maintenance only)
- `fzf` 0.74.0 → 0.74.1 released 2026-07-18, eligible ~2026-07-25 (rendering/flicker fixes, maintenance only)
- `aube` 1.26.0 → 1.27.0 released 2026-07-14, eligible ~2026-07-21. Note for next digest: v1.29.1 (still deferred) contains a fix for `aube add` bypassing the `minimumReleaseAge` gate on pinned versions — worth prioritizing once eligible.
- `usage` 3.5.4 → 3.5.5 released 2026-07-14, eligible ~2026-07-21 (flag-parsing fix, maintenance only)

## Withheld — needs manual review
- `herdr` 0.7.1: could not confidently identify the authoritative upstream repository for this tool (best candidate found was `ogulcancelik/herdr`, but this wasn't verifiable as the canonical/official source). No bump proposed; flagging for manual confirmation of the correct upstream before future audits can cover it.

## Notes
- No tool in this batch crosses a major-version boundary with breaking changes.
- Template change is value-only (no Go-template syntax touched); diff reviewed by hand for whitespace correctness per repo convention. `chezmoi` isn't installable in this sandbox to run `./render.sh` end-to-end — please run it locally before merging if you want an extra check, though the change is a straightforward literal-value substitution.


---
_Generated by [Claude Code](https://claude.ai/code/session_01StVcqhJiuzicCXbQZb6b7Y)_