### PR TITLE
chore: bump pinned tool versions (2026-07-27)

### DIFF
--- a/root/private_dot_config/mise/config.toml.tmpl
+++ b/root/private_dot_config/mise/config.toml.tmpl
@@ -1,27 +1,27 @@
 [tools]
 starship = "1.26.0"
-lazygit = "0.63.0"
+lazygit = "0.63.1"
 lazydocker = "0.25.2"
 ast-grep = "0.44.1"
 hyperfine = "1.20.0"
 duf = "0.9.1"
 fd = "10.4.2"
-fzf = "0.74.0"
+fzf = "0.74.1"
 jq = "1.8.2"
-ripgrep = "15.1.0"
+ripgrep = "15.2.0"
 lsd = "1.2.0"
 gh = "2.96.0"
 zoxide = "0.10.0"
-worktrunk = "0.67.0"
-cloudflared = "2026.7.1"
-aube = "1.26.0"
-usage = "3.5.4"
+worktrunk = "0.68.0"
+cloudflared = "2026.7.2"
+aube = "1.29.1"
+usage = "3.5.5"
 
 "github:Ataraxy-Labs/sem" = "0.21.0"
-"github:backnotprop/plannotator" = "0.23.1"
-"github:modem-dev/hunk" = "0.17.0"
+"github:backnotprop/plannotator" = "0.24.1"
+"github:modem-dev/hunk" = "0.17.3"
 {{ if ne .chezmoi.os "windows" -}}
-herdr = "0.7.3"
+herdr = "0.7.4"
 zellij = "0.44.3"
 {{- end }}
 {{ if not .isDc -}}
@@ -29,7 +29,7 @@ go = "1.26.5"
 node = "lts"
 bun = "1.3.14"
 python = "3.14.6"
-pnpm = "11.13.0"
+pnpm = "11.15.1"
 {{- end }}
 
 [settings]


### PR DESCRIPTION
## Summary

Automated audit of exact-pinned tools in `root/private_dot_config/mise/config.toml.tmpl` against upstream releases, gated by `minimum_release_age = "7d"` (eligible only if published on or before **2026-07-20**). 11 tools have an eligible, non-withheld bump; the rest are current or have updates still inside the age gate.

## Bumped in this PR

| Tool | Pinned | Target | Released |
|---|---|---|---|
| `lazygit` | 0.63.0 | **0.63.1** | 2026-07-15 |
| `fzf` | 0.74.0 | **0.74.1** | 2026-07-18 |
| `ripgrep` | 15.1.0 | **15.2.0** | 2026-07-15 |
| `worktrunk` | 0.67.0 | **0.68.0** | 2026-07-15 |
| `cloudflared` | 2026.7.1 | **2026.7.2** | 2026-07-15 |
| `aube` | 1.26.0 | **1.29.1** | 2026-07-17 |
| `usage` | 3.5.4 | **3.5.5** | 2026-07-14 |
| `github:backnotprop/plannotator` | 0.23.1 | **0.24.1** | 2026-07-20 |
| `github:modem-dev/hunk` | 0.17.0 | **0.17.3** | 2026-07-19 |
| `herdr` | 0.7.3 | **0.7.4** | 2026-07-15 |
| `pnpm` | 11.13.0 | **11.15.1** | 2026-07-19 |

### lazygit: 0.63.0 → 0.63.1
- Security: none
- Features: maintenance only — `index.lock` retry-mechanism fix, `userEvents` panic fix, Windows deadlock fix when switching between longer diffs
- Breaking: none

### fzf: 0.74.0 → 0.74.1
- Security: none
- Features:
  - Synchronized update mode reduces terminal flicker on compatible terminals
  - 10–23% less rendering output (redundant SGR sequences eliminated)
  - `.deb` packages added to release artifacts
  - Fixes: Zellij ghost-character/color artifacts, Neovim terminal cursor restore, nushell ≥0.114.0 `str downcase` deprecation
- Breaking: none

### ripgrep: 15.1.0 → 15.2.0
- Security: none
- Features:
  - `aarch64-unknown-linux-musl` release binaries
  - Directory-traversal performance improvements for large corpora
  - Respects `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`
  - gitignore-matching bugfixes spanning multiple directories
- Breaking: none

### worktrunk: 0.67.0 → 0.68.0
- Security: none
- Features:
  - `wt switch` preview tabs load on demand and cache
  - `wt config state` flags stale default-branch cache vs `origin/HEAD`
  - `wt step promote --format text|json`
  - Fixes: bare-repo config reads, relative `WORKTRUNK_PROJECT_CONFIG_PATH` resolution, shell detection via process tree, Claude/Codex plugin hook cwd/file delivery, LLM diff-prompt truncation
- Breaking: none (MSRV bumped to Rust 1.96 — build-time only, not user-facing)
- Deferred by age gate: v0.69.0/0.69.1 released 2026-07-24/25, v0.69.2 released 2026-07-25, eligible 2026-08-01

### cloudflared: 2026.7.1 → 2026.7.2
- Security:
  - Service-install hardening: macOS/Linux `cloudflared service install` now requires `--token-file` instead of raw `--token` (credential-exposure hardening; no CVE assigned)
- Features: maintenance only (Docker base-image digest bumps)
- Breaking:
  - `--token` replaced by `--token-file` for `service install` — verified this repo doesn't invoke `cloudflared service install` anywhere, so no impact
- Deferred by age gate: 2026.7.3 released 2026-07-23, eligible 2026-07-30

### aube: 1.26.0 → 1.29.1
- Security:
  - `aube add` previously bypassed the `minimumReleaseAge` gate when pinning via `latest`/dist-tags, allowing freshly-published (potentially compromised) packages to be pinned — fixed in v1.29.1 (no CVE cited)
  - Registry credentials embedded in URLs no longer leaked in publish output/errors/dry-run reports (v1.27.0, no CVE cited)
- Features:
  - v1.27.0: new `aube access` command, git-repo-URL build-approval keys, reentrant/parallel install architecture
  - v1.28.0: embeddable aube (`@jdxcode/aube-node` Node-API addon, `aube::embed` Rust API), fixed stale `file:`/`portal:` dependency installs
  - v1.29.0: maintenance only
- Breaking: none
- Deferred by age gate: v1.30.0–v1.33.1 released 2026-07-21 through 2026-07-25, v1.34.0 released 2026-07-27, eligible 2026-08-03

### usage: 3.5.4 → 3.5.5
- Security: none
- Features: maintenance only — opt-in `allow_hyphen_values` flag parsing fix for passthrough args like `-destroy`
- Breaking: none
- Deferred by age gate: v3.5.6 released 2026-07-21 (eligible 2026-07-28); v3.5.7/v3.6.0 released 2026-07-25 (eligible 2026-08-01); **v4.0.0** released 2026-07-25 (eligible 2026-08-01) — major version, will need manual review when eligible

### github:backnotprop/plannotator: 0.23.1 → 0.24.1
- Security: none
- Features:
  - PR/MR artifact gallery with inline annotation, native GitButler workspace support, expandable comment editor, `PLANNOTATOR_PORT` ranges, non-interactive background remote checks
  - v0.24.1: fix for parent-directory relative paths in `plannotator annotate`
- Breaking: none
- Deferred by age gate: v0.24.2 released 2026-07-21, eligible 2026-07-28; v0.25.0 released 2026-07-27, eligible 2026-08-03

### github:modem-dev/hunk: 0.17.0 → 0.17.3
- Security: none
- Features: maintenance only — Windows scroll-crash fix, Apple Silicon warning-spam fix, lazy-caching memory reduction, CJK/emoji rendering fixes
- Breaking: none
- Deferred by age gate: v0.17.4 released 2026-07-23, v0.17.6 released 2026-07-25, eligible 2026-08-01

### herdr: 0.7.3 → 0.7.4
- Security: none
- Features: session-modal floating terminal panes, `ui.copy_on_select` setting, copy-mode smart-case search/tmux-style word motions, Maki agent support
- Breaking: none
- Deferred by age gate: v0.7.5 released 2026-07-21, eligible 2026-07-28 — **note:** v0.7.5 introduces a breaking change (plugin installs move from per-session to global-per-user); flag for review once eligible

### pnpm: 11.13.0 → 11.15.1
- Security:
  - v11.15.0: updated `adm-zip` dependency to prevent crafted ZIP archives causing excessive memory allocation (DoS-class fix, no CVE cited)
- Features:
  - v11.14.0: new `pnpm doctor` command, regex support for `pnpm run` script matching
  - v11.15.0: resolves optional peer deps from existing dependency graph
  - v11.15.1: runtime-install parity for Node/Deno/Bun, fixed memory exhaustion during large dependency-graph resolution, stale v10 shim cleanup
- Breaking: none (stays within 11.x; v12 alpha exists but is pre-release/out of scope)
- Deferred by age gate: v11.16.0 released 2026-07-22, v11.17.0 released 2026-07-23, eligible 2026-07-30

## Current (no eligible update)

- `starship`: current
- `lazydocker`: current
- `hyperfine`: current
- `duf`: current
- `fd`: current
- `jq`: current
- `lsd`: current
- `gh`: current
- `zoxide`: current
- `zellij`: current
- `github:Ataraxy-Labs/sem`: current
- `go`: current
- `bun`: current
- `python`: current (3.14.6 already carries fixes for CVE-2026-45186, CVE-2021-4189, CVE-2026-3219 — no upgrade action)
- `ast-grep`: current — deferred by age gate: v0.45.0 released 2026-07-23, eligible 2026-07-30

## Withheld — needs manual review

None. No eligible target crosses a breaking major-version boundary.

## Test plan

- [x] Diffed `config.toml.tmpl` to confirm only the 11 audited version strings changed, no template control-flow touched
- [ ] `chezmoi` isn't installed in this session's container, so `./render.sh` couldn't be run to verify rendering — worth a quick manual `./render.sh root/private_dot_config/mise/config.toml.tmpl` check before merge
- [ ] `mise install` after merge to confirm the new pins resolve and install cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01GguNnbGf4m8uMwg1gfBS8y)_